### PR TITLE
Some minor quality-of-life additions

### DIFF
--- a/R/check.R
+++ b/R/check.R
@@ -236,13 +236,13 @@ check_abstract_before_intro <- function(path){
   abstract <- abstract[!is.na(abstract)][1]
   intro <- stringr::str_locate(tex, "introduction")[,"start"]
   intro <- intro[!is.na(intro)][1]
-  
+
   if(is.na(abstract)){
-    log_error("Unable to find abstract! Please check for the \abstract tag",
-              " in your Tex document")
+    log_error(paste0("Unable to find abstract! Please check for the \abstract ",
+                     "tag in your Tex document")
   } else if(is.na(intro)){
-    log_error("Unable to find introduction! Please check for an intro in", 
-              "your Tex document")
+    log_error(paste0("Unable to find introduction! Please check for an intro ",
+                     "in your Tex document"))
   } else if (abstract > intro){
     log_error("Abstract doesn't come before the introduction section")
   } else {
@@ -297,8 +297,9 @@ check_spelling <- function(path, dic = "en_US"){
 #' @export
 check_proposed_pkg <- function(pkg=NULL){
   if(is.null(pkg)){
-    pkg <- readline(prompt = "What's the name of package being proposed in ",
-                    "the article? If none, please enter 0. ")
+    pkg <- readline(prompt = paste0("What's the name of package being ",
+                                    "proposed in the article? If none, please ",
+                                    "enter 0. "))
   }
 
   if (pkg != 0) {

--- a/man/checks.Rd
+++ b/man/checks.Rd
@@ -32,7 +32,7 @@ check_abstract_before_intro(path)
 
 check_spelling(path, dic = "en_US")
 
-check_proposed_pkg()
+check_proposed_pkg(pkg = NULL)
 
 check_packages_available(path)
 }


### PR DESCRIPTION
I'm preparing a manuscript for the R Journal now, and have been super impressed with `rjtools` as a useful helper. While using it, I noticed a couple things that were easy fixes that improved my quality-of-life while using the package, so this pull request would include these in the package for everyone else.

1. Edited the error/success messages for `check_title()`.
    - Currently, `check_title()` gives a recommendation to use `toTitleCase()` when the title is correctly formatted. This commit moves that recommendation to the error condition rather than the success condition, where it seems to make more sense. 
    - I also explicitly specify that `toTitleCase()` comes from the `tools` package because it took me a bit to realize that wasn't an `rjtools` function.
2. Added `NA` handling to the `check_abstract_before_intro()` function
    - In my document, I specify the introduction using `\section{Introduction}`, which isn't picked up by the `check_abstract_before_intro` function for some reason. This makes it return `NA`, which throws an error and stops the workflow with `Error in if (abstract < intro) { : missing value where TRUE/FALSE needed`
3. Added an option to `check_proposed_package()` that allows specifying the package as an argument rather than a user input
    - Purely for convenience, I added an argument to this function that lets you specify the package you're checking rather than waiting for user input via `readline`. This was nice because I could just run the whole suite of `check_XXX` functions without needing to manually enter the info each time.
    - Argument has been added with a default of `NULL`, so this should also work as-is with existing packages.

Package builds and installs nicely on my machine, but R CMD CHECK throws an error because `the lazy-load database rjtools.rdb is corrupt` but I don't think I touched that, so it shouldn't be an issue.