### PR TITLE
Adding `web_only` parameter for texor

### DIFF
--- a/R/rj_web_article.R
+++ b/R/rj_web_article.R
@@ -9,12 +9,13 @@
 #'   and `rticles::rjournal_article()` for pdf articles.
 #' @inheritParams distill::distill_article
 #' @param legacy_pdf whether an article is from the past and only have pdf version
+#' @param web_only additional param for skipping PDF compilation for legacy articles
 #' @importFrom rlang caller_env env_poke
 #' @return the rendered R Journal article
 #' @export
 #' @rdname rjournal_article
 rjournal_web_article <- function(toc = FALSE, self_contained = FALSE,
-                                 legacy_pdf = FALSE, ...) {
+                                 legacy_pdf = FALSE,  web_only = FALSE,...) {
   args <- c()
   base_format <- distill::distill_article(
     self_contained = self_contained, toc = toc, ...
@@ -127,7 +128,7 @@ rjournal_web_article <- function(toc = FALSE, self_contained = FALSE,
                             output_dir) {
 
     # Add embedded PDF
-    embed_pdf <- if(legacy_pdf) {
+    embed_pdf <- if(legacy_pdf &  (! web_only)){
       whisker::whisker.render(
 '<div class="l-page">
   <embed src="{{slug}}.pdf" type="application/pdf" height="955px" width="100%">
@@ -175,7 +176,7 @@ rjournal_web_article <- function(toc = FALSE, self_contained = FALSE,
         yaml::as.yaml(metadata),
         "---",
         "",
-        if(legacy_pdf) embed_pdf else input[(front_matter_delimiters[2]+1):length(input)],
+        if(legacy_pdf & (!web_only)) embed_pdf else input[(front_matter_delimiters[2]+1):length(input)],
         "",
         appendix
       ),
@@ -196,6 +197,9 @@ rjournal_web_article <- function(toc = FALSE, self_contained = FALSE,
 
     # Skip rendering pdf for non-article pages
     if(is.null(render_pdf)) return()
+
+    # Skip rendering pdf for web_only article
+    if(web_only) return()
 
     # Update legacy PDF metadata just by changing the wrapper
     if (legacy_pdf) {

--- a/R/rj_web_article.R
+++ b/R/rj_web_article.R
@@ -9,13 +9,13 @@
 #'   and `rticles::rjournal_article()` for pdf articles.
 #' @inheritParams distill::distill_article
 #' @param legacy_pdf whether an article is from the past and only have pdf version
-#' @param web_only additional param for skipping PDF compilation for legacy articles
+#' @param web_only additional param for embedding PDF or using Rmd to produce HTML
 #' @importFrom rlang caller_env env_poke
 #' @return the rendered R Journal article
 #' @export
 #' @rdname rjournal_article
 rjournal_web_article <- function(toc = FALSE, self_contained = FALSE,
-                                 legacy_pdf = FALSE,  web_only = FALSE,...) {
+                                 legacy_pdf = FALSE, web_only = FALSE, ...) {
   args <- c()
   base_format <- distill::distill_article(
     self_contained = self_contained, toc = toc, ...
@@ -128,7 +128,7 @@ rjournal_web_article <- function(toc = FALSE, self_contained = FALSE,
                             output_dir) {
 
     # Add embedded PDF
-    embed_pdf <- if(legacy_pdf &  (! web_only)){
+    embed_pdf <- if(! web_only){
       whisker::whisker.render(
 '<div class="l-page">
   <embed src="{{slug}}.pdf" type="application/pdf" height="955px" width="100%">
@@ -176,7 +176,7 @@ rjournal_web_article <- function(toc = FALSE, self_contained = FALSE,
         yaml::as.yaml(metadata),
         "---",
         "",
-        if(legacy_pdf & (!web_only)) embed_pdf else input[(front_matter_delimiters[2]+1):length(input)],
+        if(! web_only) embed_pdf else input[(front_matter_delimiters[2]+1):length(input)],
         "",
         appendix
       ),
@@ -197,9 +197,6 @@ rjournal_web_article <- function(toc = FALSE, self_contained = FALSE,
 
     # Skip rendering pdf for non-article pages
     if(is.null(render_pdf)) return()
-
-    # Skip rendering pdf for web_only article
-    if(web_only) return()
 
     # Update legacy PDF metadata just by changing the wrapper
     if (legacy_pdf) {

--- a/man/rjournal_article.Rd
+++ b/man/rjournal_article.Rd
@@ -29,7 +29,7 @@ its size).}
 
 \item{legacy_pdf}{whether an article is from the past and only have pdf version}
 
-\item{web_only}{additional param for skipping PDF compilation for legacy articles}
+\item{web_only}{additional param for embedding PDF or using Rmd to produce HTML}
 }
 \value{
 the rendered R Journal article

--- a/man/rjournal_article.Rd
+++ b/man/rjournal_article.Rd
@@ -11,6 +11,7 @@ rjournal_web_article(
   toc = FALSE,
   self_contained = FALSE,
   legacy_pdf = FALSE,
+  web_only = FALSE,
   ...
 )
 }
@@ -27,6 +28,8 @@ its size).}
 \item{toc}{\code{TRUE} to include a table of contents in the output}
 
 \item{legacy_pdf}{whether an article is from the past and only have pdf version}
+
+\item{web_only}{additional param for skipping PDF compilation for legacy articles}
 }
 \value{
 the rendered R Journal article


### PR DESCRIPTION
This parameter is required for the texor package to properly convert articles because :
1. Currently `legacy_pdf` option will not include the generated markdown contents.
2. Going for normal mode will invoke PDF compilation of the Rmarkdown, which is not desired.