### PR TITLE
support setting subtitle from YAML in LaTeX template

### DIFF
--- a/inst/rmarkdown/templates/rjournal/resources/template.tex
+++ b/inst/rmarkdown/templates/rjournal/resources/template.tex
@@ -1,5 +1,12 @@
 % !TeX root = RJwrapper.tex
 \title{$title$}
+
+$if(subtitle)$
+\subtitle{%
+$subtitle$
+}
+$endif$
+
 \author{by $for(author)$$author.name$$sep$, $endfor$}
 
 \maketitle


### PR DESCRIPTION
The R Journal LaTeX template always allowed to set `\subtitle{}` which we used regularly for the "Changes on CRAN" section. This PR supports passing the `subtitle` specification from the YAML to LaTeX `template.tex` analogous to how `abstract` is processed.

It would be great to support the same in `rjdistill.html` but I'm not familiar enough with distill to enable the same support there.