### PR TITLE
Conversion Note : to notify that the article is converted using texor.

### DIFF
--- a/R/rj_web_article.R
+++ b/R/rj_web_article.R
@@ -177,6 +177,13 @@ rjournal_web_article <- function(toc = FALSE, self_contained = FALSE,
         data <- c(data, list(BIOC = BIOC))
       }
     }
+    if (web_only && legacy_pdf) {
+      TEXOR <- "This article is converted from a Legacy LaTeX article using the
+                [texor](https://cran.r-project.org/package=texor) package.
+                The pdf version is the official version. To report a problem with the html,
+                refer to CONTRIBUTE on the R Journal homepage."
+      data <- c(data, list(TEXOR = TEXOR))
+    }
 
     template <- xfun::read_utf8(system.file("appendix.md", package = "rjtools"))
     appendix <- whisker::whisker.render(template, data)

--- a/inst/appendix.md
+++ b/inst/appendix.md
@@ -23,3 +23,10 @@ Supplementary materials are available in addition to this article. It can be dow
 {{BIOC}}
 {{/BIOC}}
 
+{{#TEXOR}}
+## Note {.appendix}
+
+{{TEXOR}}
+{{/TEXOR}}
+
+


### PR DESCRIPTION
This patch will add a note for legacy articles converted to html in the appendix section of the article.
Issue #72 