### PR TITLE
fix #122

### DIFF
--- a/inst/sec-depth.lua
+++ b/inst/sec-depth.lua
@@ -3,16 +3,26 @@ function Pandoc (doc)
   -- `true` ensures that headings are numbered.
   doc.blocks = pandoc.utils.make_sections(true, nil, doc.blocks)
 
-  -- Shift the heading levels by 1
-  doc.blocks = doc.blocks:walk {
-    Header = function (h)
-      if h.level > 2 then
-        h.classes:insert 'unnumbered'
-      end
-      h.level = h.level + 1
-      return h
+  -- Check if doc.blocks is not nil
+  if doc.blocks then
+    -- Check if walk method exists
+    if doc.blocks.walk then
+      -- Shift the heading levels by 1
+      doc.blocks = doc.blocks:walk {
+        Header = function (h)
+          if h.level > 2 then
+            h.classes:insert 'unnumbered'
+          end
+          h.level = h.level + 1
+          return h
+        end
+      }
+    else
+      print("Error: walk method does not exist")
     end
-  }
+  else
+    print("Error: doc.blocks is nil")
+  end
 
   -- Return the modified document
   return doc


### PR DESCRIPTION
I added some checks and now I can create both html and pdf outputs.

However, the console says:

```
...
--include-in-header /home/pacha/R/x86_64-pc-linux-gnu-library/4.3/rjtools/rjdistill.html --filter /usr/bin/pandoc-citeproc 

Error: walk method does not exist


Output created
...
```