### PR TITLE
Fixed emph check in `check_abstract()`

### DIFF
--- a/R/check.R
+++ b/R/check.R
@@ -347,7 +347,7 @@ check_abstract <- function(path){
 
   if (has_special_format){
     log_error("Abstract should be plain text without package markups,
-    mathmatic notations, citation, or other formattings."
+    mathematical notations, citation, or other formattings."
     )
   } else{
     log_success("Abstract formatted in plain text.")
@@ -361,7 +361,7 @@ check_abstract_str <- function(str){
   # citation
   citations <- grepl("\\cite\\{.*\\}|\\citep|\\citet", str)
 
-  others <-  grepl("texttt|\\$.*\\$|emph|proglang", str)
+  others <-  grepl("\\texttt|\\$.*\\$|\\emph|\\proglang", str)
 
   any(c(pkgs, citations, others))
 }

--- a/tests/testthat/test-check.R
+++ b/tests/testthat/test-check.R
@@ -53,6 +53,8 @@ test_that("check abstract works", {
   expect_true(check_abstract_str(str))
   str <- "neither is \\emph{sdkfjls}"
   expect_true(check_abstract_str(str))
+  str <- "but emphasize that this is allowed"
+  expect_false(check_abstract_str(str))
   str <- "You should generally not cite \\proglang{R}. "
   expect_true(check_abstract_str(str))
 


### PR DESCRIPTION
I ran into this minor issue when writing an article. I couldn't figure out why my abstract wasn't passing the automatic checks. After looking into this further, part of the check looks for the text: `emph` (among other things like`texttt`, math-mode LaTeX dollar-signs, and `proglang`). The problem is that `emph` is a valid human-readable text, and should only be flagged if it's used inappropriately, such as `\emph{italic text here}`. 

As a minimum working example of the problem here, consider an abstract that contains the text: 

> This work emphasizes the importance of ...

This text gets flagged for not being plain text, with the message being: 

> **ERROR: Abstract should be plain text without package markups, mathmatic notations, citation, or other formattings.**

To fix this, I propose that you just look for instances of `\emph`, rather than `emph`, as done in the pull-request and in the search for words like `\cite`. I also now only search for `\texttt` and `\proglang` (with the inclusion of the backslash). Although I can't think of instances where this set of characters would appear naturally in text, I guess it might be possible so might as well only check for when the characters are used for markups / formatting.

The pull-request also contains a minor fix to the error message, changing `mathmatic` -> `mathematical`. 