### PR TITLE
fix: correct ORCID casing in templates

### DIFF
--- a/inst/paper-with-errors/paper-with-errors.tex
+++ b/inst/paper-with-errors/paper-with-errors.tex
@@ -83,7 +83,7 @@ University of Little Mates\\%
 Department of Letter Q\\ Somewhere, Australia\\
 %
 \url{https://www.britannica.com/animal/quokka}\\%
-\textit{ORCiD: \href{https://orcid.org/0000-1721-1511-1101}{0000-1721-1511-1101}}\\%
+\textit{ORCID: \href{https://orcid.org/0000-1721-1511-1101}{0000-1721-1511-1101}}\\%
 \href{mailto:qquo@ulm.edu}{\nolinkurl{qquo@ulm.edu}}%
 }
 
@@ -93,6 +93,6 @@ University of Little Mates\\%
 Department of Letter B\\ Somewhere, Australia\\
 %
 \url{https://www.britannica.com/animal/bilby}\\%
-\textit{ORCiD: \href{https://orcid.org/0000-0002-0912-0225}{0000-0002-0912-0225}}\\%
+\textit{ORCID: \href{https://orcid.org/0000-0002-0912-0225}{0000-0002-0912-0225}}\\%
 \href{mailto:bbil@ulm.edu}{\nolinkurl{bbil@ulm.edu}}%
 }

--- a/inst/rmarkdown/templates/rjournal/resources/template.tex
+++ b/inst/rmarkdown/templates/rjournal/resources/template.tex
@@ -33,7 +33,7 @@ $author.affiliation2$\\%
 $for(author.address2)$$author.address2$$sep$\\ $endfor$\\
 $endif$%
 $if(author.url)$$author.url$\\$endif$%
-$if(author.orcid)$\textit{ORCiD: \href{https://orcid.org/$author.orcid$}{$author.orcid$}}\\$endif$%
+$if(author.orcid)$\textit{ORCID: \href{https://orcid.org/$author.orcid$}{$author.orcid$}}\\$endif$%
 $if(author.email)$$author.email$$endif$%
 }
 

--- a/inst/sample-article/article.tex
+++ b/inst/sample-article/article.tex
@@ -115,7 +115,7 @@ University of Little Mates\\%
 Department of Letter Q\\ Somewhere, Australia\\
 %
 \url{https://www.britannica.com/animal/quokka}\\%
-\textit{ORCiD: \href{https://orcid.org/0000-1721-1511-1101}{0000-1721-1511-1101}}\\%
+\textit{ORCID: \href{https://orcid.org/0000-1721-1511-1101}{0000-1721-1511-1101}}\\%
 \href{mailto:qquo@ulm.edu}{\nolinkurl{qquo@ulm.edu}}%
 }
 
@@ -125,6 +125,6 @@ University of Little Mates\\%
 Department of Letter B\\ Somewhere, Australia\\
 %
 \url{https://www.britannica.com/animal/bilby}\\%
-\textit{ORCiD: \href{https://orcid.org/0000-0002-0912-0225}{0000-0002-0912-0225}}\\%
+\textit{ORCID: \href{https://orcid.org/0000-0002-0912-0225}{0000-0002-0912-0225}}\\%
 \href{mailto:bbil@ulm.edu}{\nolinkurl{bbil@ulm.edu}}%
 }

--- a/tests/bad-article/article.tex
+++ b/tests/bad-article/article.tex
@@ -119,7 +119,7 @@ University of Little Mates\\%
 Department of Letter Q\\ Somewhere, Australia\\
 %
 \url{https://www.britannica.com/animal/quokka}\\%
-\textit{ORCiD: \href{https://orcid.org/0000-1721-1511-1101}{0000-1721-1511-1101}}\\%
+\textit{ORCID: \href{https://orcid.org/0000-1721-1511-1101}{0000-1721-1511-1101}}\\%
 \href{mailto:qquo@ulm.edu}{\nolinkurl{qquo@ulm.edu}}%
 }
 
@@ -129,6 +129,6 @@ University of Little Mates\\%
 Department of Letter B\\ Somewhere, Australia\\
 %
 \url{https://www.britannica.com/animal/bilby}\\%
-\textit{ORCiD: \href{https://orcid.org/0000-0002-0912-0225}{0000-0002-0912-0225}}\\%
+\textit{ORCID: \href{https://orcid.org/0000-0002-0912-0225}{0000-0002-0912-0225}}\\%
 \href{mailto:bbil@ulm.edu}{\nolinkurl{bbil@ulm.edu}}%
 }


### PR DESCRIPTION
## Summary
- Fix ORCID label casing in the rmarkdown template
- Update sample and test articles to match ORCID capitalization

## Issue
Closes #146

## Test Plan
- Not run (docs/latex text change only)