### PR TITLE
Minor corrections in vignettes

### DIFF
--- a/vignettes/create_article.Rmd
+++ b/vignettes/create_article.Rmd
@@ -48,7 +48,7 @@ Please ensure that you stick to this folder structure when working with an R Jou
 
 ## Your first knit
 
-To knit the `Rmd` file, you can use either through the RStudio `knit` button, or type the following command in the R console:  
+To knit the `Rmd` file, you can use either the RStudio `knit` button, or type the following command in the R console:  
 
 ```{r eval = FALSE}
 rmarkdown::render("quokka-bilby.Rmd")

--- a/vignettes/create_article.Rmd
+++ b/vignettes/create_article.Rmd
@@ -38,7 +38,7 @@ The `create_article()` function will create the following files and folders:
 
 The `.tex`, and `.sty` files make sure all the *R Journal* articles follow the same latex and reference style and should not be modified unless there is a strong reason to do so.
 
-The `name` argument changes the name of the main R Markdown document, for example, if you wish to use `quokka-bilby` as the file name instead of `article`, create the article with: 
+The `name` argument changes the name of the main R Markdown document, for example, if you wish to use `quokka-bilby` as the file name instead of `test`, create the article with: 
 
 ```{r eval = FALSE}
 create_article(name = "quokka-bilby")

--- a/vignettes/format-details.Rmd
+++ b/vignettes/format-details.Rmd
@@ -32,8 +32,8 @@ This has these components:
 ```
 output:
   rjtools::rjournal_article
+bibliography: RJreferences.bib
 ```
-- `bibliography: RJreferences.bib`
 
 # Figures
 
@@ -48,7 +48,7 @@ Of course, if only a static plot is to be rendered in both outputs, a single cod
 For a static graph, use `\@ref(fig:penguins)` for in-text reference and your code chunk should look something like this:
 
 ````markdown
-`r ''````{r penguins, fig.cap="This is the figure caption"}
+`r ''````{r penguins, fig.cap="This is the figure caption."}
 penguins %>% 
   ggplot(aes(x = flipper_length_mm, 
              y = body_mass_g, 
@@ -84,7 +84,7 @@ plotly::ggplotly(p1)
 
 Notice here you need `eval=knitr::is_html_output()` and `eval=knitr::is_latex_output()` to make sure that the pdf output only evaluates the first chunk and the html output only evaluates the second. 
 
-For in-text citation, you will something like this: 
+For in-text citation, you will need something like this: 
 
     Figure \@ref(fig:`r "\u0060r"` ifelse(knitr::is_html_output(), 'penguins-interactive', 'penguins-static')`r "\u0060"` shows ...
     
@@ -113,7 +113,7 @@ Notice that `fig.width` and `fig.height` still apply here and `layout` option wi
   - `plotly::ggplotly(p, width = ..., height = ...)`, and 
   - `ggiraph::girafe(p, width_svg = ..., height_svg = ...)`. 
   
-Sizing these figures should via the relevant arguments rather than the chunk options.
+Sizing these figures should be done via the relevant arguments rather than the chunk options.
 
 ## Captions with special formatting
 
@@ -188,7 +188,7 @@ Both equations will be numbered, and referenced with  `\@ref(eq:parityLoss2)`. S
 
 # Citations
 
-The citation style will be added during the building process and you can find the csl file [here](https://github.com/rjournal/rjtools/blob/main/inst/rjournal.csl). This style adopts a "capitalize-first" text case on title, which means it will capitalise the first world, including the one after the colon, and use lowercase for the rest. If you would like to preserve the text case of the title in the reference, wrap the word with curly braces. A common example of this is to preserve the lowercase R package name: 
+The citation style will be added during the building process and you can find the csl file [here](https://github.com/rjournal/rjtools/blob/main/inst/rjournal.csl). This style adopts a "capitalize-first" text case on title, which means it will capitalise the first word, including the one after the colon, and use lowercase for the rest. If you would like to preserve the text case of the title in the reference, wrap the word with curly braces. A common example of this is to preserve the lowercase R package name: 
 
 ```
 @Manual{crosstalk,


### PR DESCRIPTION
The `create_article` vignette currently says

> if you wish to use `quokka-bilby` as the file name instead of `article`

but based on the example just above this text, it should say

> if you wish to use `quokka-bilby` as the file name instead of `test`

A minor correction, but might as well :)